### PR TITLE
[PHI-18] Cleanup cells during block operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - [CHORE] Loosen floki dependency & update
 - [CHORE] Update phoenix_live_view dependency
 - [TWEAK] Use `n` to split lines in block component, instead of `<br/>`
+- [TWEAK] Clean up redundant cells during block operations
 
 # 0.9.3 2022-05-25
 

--- a/cypress/integration/block.spec.ts
+++ b/cypress/integration/block.spec.ts
@@ -14,6 +14,15 @@ const blockCell = (blockIndex: number, cellIndex: number) =>
 
 const visitNew = () => cy.visit('/documents/new').get('.phx-connected');
 
+/**
+ * Selects first matched occurrence of a string within the specified cell
+ *
+ * Cypress does not provide commands for selection of specific text.
+ *
+ * One can `cy.type('{selectAll}')`, but actions such as `{shift+rightArrow}` do
+ * not add to selection. This executes js int he browser, to synthetise the
+ * selection that way.
+ */
 const selectText = (blockIndex: number, cellIndex: number, text: string) =>
   block(blockIndex)
     .focus()

--- a/cypress/integration/block.spec.ts
+++ b/cypress/integration/block.spec.ts
@@ -12,6 +12,28 @@ const focusStartOfBlock = (blockIndex: number) =>
 const blockCell = (blockIndex: number, cellIndex: number) =>
   block(blockIndex).find('[data-cell-id]').eq(cellIndex);
 
+const visitNew = () => cy.visit('/documents/new').get('.phx-connected');
+
+const selectText = (blockIndex: number, cellIndex: number, text: string) =>
+  block(blockIndex)
+    .focus()
+    .find('[data-cell-id]')
+    .eq(cellIndex)
+    .then((cell) => {
+      const el = cell[0];
+      const document = el.ownerDocument;
+      const textIndex = el.innerText.indexOf(text);
+      const range = document.createRange();
+      console.log(el.innerText);
+
+      range.setStart(el.childNodes[0], textIndex);
+      range.setEnd(el.childNodes[0], textIndex + text.length);
+
+      const selection = document.getSelection();
+      selection.removeAllRanges();
+      selection.addRange(range);
+    });
+
 it('loads default content', () => {
   const page = new NewPage();
   page.visit();
@@ -87,6 +109,22 @@ it('handles new line at end of block', () => {
     'contain.text',
     'This is your first paragraph.A new line'
   );
+});
+
+it('allows toggling styles styles within a block', () => {
+  visitNew();
+
+  selectText(1, 0, 'is').type('{meta+b}');
+  blockCell(1, 1).should('have.text', 'is').should('have.class', 'bold');
+
+  selectText(1, 1, 'is').type('{meta+b}');
+  blockCell(1, 0).should('have.text', 'This is your first paragraph.');
+
+  selectText(1, 0, 'your').type('{meta+i}');
+  blockCell(1, 1).should('have.text', 'your').should('have.class', 'italic');
+
+  selectText(1, 1, 'your').type('{meta+i}');
+  blockCell(1, 0).should('have.text', 'This is your first paragraph.');
 });
 
 describe('H1', () => {

--- a/lib/philtre/block/clean_empty_cells.ex
+++ b/lib/philtre/block/clean_empty_cells.ex
@@ -1,0 +1,73 @@
+defmodule Philtre.Editor.Block.CleanEmptyCells do
+  @moduledoc """
+  Cleans up empty cells from a block.
+
+  Various block actions will result in empty cells being left over. These are
+  redundant and can be removed without any consequences, resulting in a simpler
+  html.
+  """
+  alias Philtre.Editor.Block
+  alias Philtre.Editor.Block.Cell
+  alias Philtre.Editor.Block.Selection
+
+  @doc """
+  Removes empty cells from a block.
+
+  Since a new block must contain an empty cell, that one is not cleaned up in
+  this scenario.
+
+  If block selection starts and/or ends within a cleaned up cell, that edge of
+  selection is moved into the next appropriate cell.
+  """
+  @spec call(Block.t()) :: Block.t()
+  def call(%Block{cells: []} = block), do: block
+  def call(%Block{cells: [_]} = block), do: block
+
+  def call(%Block{} = block) do
+    {new_cells, new_selection} = clean([], block.cells, block.selection)
+    %{block | cells: new_cells, selection: new_selection}
+  end
+
+  @spec clean(
+          list(Cell.t()),
+          list(Cell.t()),
+          Selection.t() | nil
+        ) :: {list(Cell.t()), Selection.t() | nil}
+  defp clean(cleaned, [%Cell{} = current, %Cell{} = next | rest], selection_or_nil) do
+    if current.text === "" do
+      selection = move_selection(selection_or_nil, current, next)
+      clean(cleaned, [next] ++ rest, selection)
+    else
+      clean(cleaned ++ [current], [next] ++ rest, selection_or_nil)
+    end
+  end
+
+  defp clean(cleaned, uncleaned, selection_or_nil), do: {cleaned ++ uncleaned, selection_or_nil}
+
+  @spec move_selection(Selection.t() | nil, Cell.t(), Cell.t()) :: Selection.t()
+  defp move_selection(nil, %Cell{}, %Cell{}), do: nil
+  defp move_selection(%Selection{start_id: nil} = selection, %Cell{}, %Cell{}), do: selection
+
+  defp move_selection(%Selection{} = selection, %Cell{} = cleaned_cell, %Cell{} = new_cell) do
+    {new_start_id, new_start_offset} =
+      if selection.start_id == cleaned_cell.id do
+        {new_cell.id, 0}
+      else
+        {selection.start_id, selection.start_offset}
+      end
+
+    {new_end_id, new_end_offset} =
+      if selection.end_id == cleaned_cell.id do
+        {new_cell.id, 0}
+      else
+        {selection.end_id, selection.end_offset}
+      end
+
+    %Selection{
+      start_id: new_start_id,
+      start_offset: new_start_offset,
+      end_id: new_end_id,
+      end_offset: new_end_offset
+    }
+  end
+end

--- a/lib/philtre/block/reduce.ex
+++ b/lib/philtre/block/reduce.ex
@@ -1,0 +1,77 @@
+defmodule Philtre.Editor.Block.Reduce do
+  @moduledoc """
+  Reduces a block by merging in cells with the same styling (modifiers).
+
+  The aim is to reduce the overall number of redundant cells and keep the output HTML as simple as
+  possible.
+  """
+  alias Philtre.Editor.Block
+  alias Philtre.Editor.Block.Cell
+  alias Philtre.Editor.Block.Selection
+
+  @doc """
+  Reduces the block by joining neighboring cells with the same modifiers.
+
+  Since selection is defined by cell ids, it needs to be updated as well.
+  """
+  @spec call(Block.t()) :: Block.t()
+  def call(%Block{cells: []} = block), do: block
+  def call(%Block{cells: [_]} = block), do: block
+
+  def call(%Block{cells: [first | rest]} = block) do
+    {new_cells, new_selection} =
+      Enum.reduce(
+        rest,
+        {[first], block.selection},
+        fn %Cell{} = current_cell, {previous_cells, selection_or_nil} ->
+          %Cell{} = previous_cell = Enum.at(previous_cells, -1)
+
+          if Enum.sort(current_cell.modifiers) == Enum.sort(previous_cell.modifiers) do
+            other_cells = Enum.drop(previous_cells, -1)
+            merged = merge(previous_cell, current_cell)
+            selection = update_selection(selection_or_nil, previous_cell, current_cell)
+
+            {other_cells ++ [merged], selection}
+          else
+            {previous_cells ++ [current_cell], selection_or_nil}
+          end
+        end
+      )
+
+    %{block | cells: new_cells, selection: new_selection}
+  end
+
+  @spec merge(Cell.t(), Cell.t()) :: Cell.t()
+  defp merge(%Cell{} = to, %Cell{} = from), do: %{to | text: to.text <> from.text}
+
+  @spec update_selection(Selection.t() | nil, Cell.t(), Cell.t()) :: Selection.t() | nil
+
+  defp update_selection(
+         %Selection{} = selection,
+         %Cell{} = to,
+         %Cell{} = from
+       ) do
+    {new_start_id, new_start_offset} =
+      if selection.start_id == from.id do
+        {to.id, selection.start_offset + String.length(to.text)}
+      else
+        {selection.start_id, selection.start_offset}
+      end
+
+    {new_end_id, new_end_offset} =
+      if selection.end_id == from.id do
+        {to.id, selection.end_offset + String.length(to.text)}
+      else
+        {selection.end_id, selection.end_offset}
+      end
+
+    %Selection{
+      start_id: new_start_id,
+      end_id: new_end_id,
+      start_offset: new_start_offset,
+      end_offset: new_end_offset
+    }
+  end
+
+  defp update_selection(nil, %Cell{}, %Cell{}), do: nil
+end

--- a/test/philtre/block/clean_empty_cells.test.exs
+++ b/test/philtre/block/clean_empty_cells.test.exs
@@ -1,0 +1,100 @@
+defmodule Philtre.Editor.Block.ReduceTest do
+  use ExUnit.Case, async: true
+
+  alias Philtre.Editor.Block
+  alias Philtre.Editor.Block.Cell
+  alias Philtre.Editor.Block.CleanEmptyCells
+  alias Philtre.Editor.Block.Selection
+
+  test "returns same block when no cells" do
+    block = %Block{cells: []}
+    assert CleanEmptyCells.call(block) == block
+  end
+
+  test "returns same block when one cell" do
+    block = %Block{cells: [Cell.new()]}
+    assert CleanEmptyCells.call(block) == block
+  end
+
+  test "out of two cells with empty content, discards the first one" do
+    block = %Block{
+      cells: [
+        %Cell{id: "1", text: ""},
+        %Cell{id: "2", text: ""}
+      ]
+    }
+
+    assert %{cells: [cell]} = CleanEmptyCells.call(block)
+    assert cell == Enum.at(block.cells, 1)
+  end
+
+  test "out of multiple cells with empty content, keeps the last one" do
+    block = %Block{
+      cells: [
+        %Cell{id: "1", text: ""},
+        %Cell{id: "2", text: ""},
+        %Cell{id: "3", text: ""}
+      ]
+    }
+
+    assert %{cells: [cell]} = CleanEmptyCells.call(block)
+    assert cell == Enum.at(block.cells, 2)
+  end
+
+  test "cleans up multiple ocurrences of empty cells" do
+    block = %Block{
+      cells: [
+        %Cell{id: "1", text: ""},
+        %Cell{id: "2", text: ""},
+        %Cell{id: "3", text: "foo"},
+        %Cell{id: "4", text: "bar"},
+        %Cell{id: "5", text: ""},
+        %Cell{id: "6", text: "baz"}
+      ]
+    }
+
+    assert %{cells: cells} = CleanEmptyCells.call(block)
+
+    assert cells == [
+             %Cell{id: "3", text: "foo"},
+             %Cell{id: "4", text: "bar"},
+             %Cell{id: "6", text: "baz"}
+           ]
+  end
+
+  test "when cleaned cell had entire selection, moves it to first clean block" do
+    block = %Block{
+      cells: [
+        %Cell{id: "1", text: ""},
+        %Cell{id: "2", text: ""},
+        %Cell{id: "3", text: ""}
+      ],
+      selection: %Selection{start_id: "1", end_id: "1", start_offset: 0, end_offset: 0}
+    }
+
+    assert %{selection: selection} = CleanEmptyCells.call(block)
+
+    assert selection == %Selection{
+             start_id: "3",
+             end_id: "3",
+             start_offset: 0,
+             end_offset: 0
+           }
+  end
+
+  test "when cleaned cell had start of selection, moves it to first clean block" do
+    block = %Block{
+      cells: [
+        %Cell{id: "1", text: ""},
+        %Cell{id: "2", text: ""},
+        %Cell{id: "3", text: ""},
+        %Cell{id: "4", text: "foo"}
+      ],
+      selection: %Selection{start_id: "1", end_id: "4", start_offset: 0, end_offset: 2}
+    }
+
+    assert %{selection: selection} = CleanEmptyCells.call(block)
+
+    assert selection == %Selection{start_id: "4", end_id: "4", start_offset: 0, end_offset: 2}
+  end
+end

--- a/test/philtre/block/reduce_test.exs
+++ b/test/philtre/block/reduce_test.exs
@@ -1,0 +1,132 @@
+defmodule Philtre.Editor.Block.ReduceTest do
+  use ExUnit.Case, async: true
+
+  alias Philtre.Editor.Block
+  alias Philtre.Editor.Block.Cell
+  alias Philtre.Editor.Block.Reduce
+  alias Philtre.Editor.Block.Selection
+
+  test "returns same block when no cells" do
+    block = %Block{cells: []}
+    assert Reduce.call(block) == block
+  end
+
+  test "returns same block when one cell" do
+    block = %Block{cells: [Cell.new()]}
+    assert Reduce.call(block) == block
+  end
+
+  test "returns same block when nothing to reduce" do
+    block = %Block{
+      cells: [
+        %Cell{text: "foo", modifiers: []},
+        %Cell{text: "bar", modifiers: ["strong"]}
+      ]
+    }
+
+    assert Reduce.call(block) == block
+  end
+
+  test "merges two mergeable cells" do
+    block = %Block{
+      cells: [
+        %Cell{text: "foo", modifiers: []},
+        %Cell{text: "bar", modifiers: []}
+      ]
+    }
+
+    assert %{cells: [%{text: "foobar"}]} = Reduce.call(block)
+  end
+
+  test "merges more than two mergeable cells" do
+    block = %Block{
+      cells: [
+        %Cell{text: "foo", modifiers: []},
+        %Cell{text: "bar", modifiers: []},
+        %Cell{text: "baz", modifiers: []}
+      ]
+    }
+
+    assert %{cells: [%{text: "foobarbaz"}]} = Reduce.call(block)
+  end
+
+  test "merges multiple sets of mergeable cells" do
+    block = %Block{
+      cells: [
+        %Cell{text: "foo", modifiers: []},
+        %Cell{text: "bar", modifiers: []},
+        %Cell{text: "baz", modifiers: []},
+        %Cell{text: "bam", modifiers: ["strong"]},
+        %Cell{text: "bat", modifiers: ["strong"]}
+      ]
+    }
+
+    assert %{cells: [%{text: "foobarbaz"}, %{text: "bambat"}]} = Reduce.call(block)
+  end
+
+  test "updates selection when it's exclusively in the merged cell" do
+    block = %Block{
+      cells: [
+        %Cell{id: "1", text: "foo", modifiers: []},
+        %Cell{id: "2", text: "bar", modifiers: []}
+      ],
+      # text "ar" in cell "2" is selected
+      selection: %Selection{
+        start_id: "2",
+        end_id: "2",
+        start_offset: 1,
+        end_offset: 2
+      }
+    }
+
+    assert %{selection: selection} = Reduce.call(block)
+    assert selection == %Selection{start_id: "1", end_id: "1", start_offset: 4, end_offset: 5}
+  end
+
+  test "updates selection when it spans to and from cell" do
+    block = %Block{
+      cells: [
+        %Cell{id: "1", text: "foo", modifiers: []},
+        %Cell{id: "2", text: "bar", modifiers: []}
+      ],
+      # text "ar" in cell "2" is selected
+      selection: %Selection{
+        start_id: "1",
+        end_id: "2",
+        start_offset: 1,
+        end_offset: 2
+      }
+    }
+
+    assert %{selection: selection} = Reduce.call(block)
+    assert selection == %Selection{start_id: "1", end_id: "1", start_offset: 1, end_offset: 5}
+  end
+
+  test "updates selection when it starts in from cell and ends in another cell" do
+    block = %Block{
+      cells: [
+        %Cell{id: "1", text: "foo", modifiers: []},
+        %Cell{id: "2", text: "bar", modifiers: []},
+        %Cell{id: "3", text: "baz", modifiers: ["strong"]}
+      ],
+      selection: %Selection{start_id: "2", end_id: "3", start_offset: 1, end_offset: 2}
+    }
+
+    assert %{selection: selection} = Reduce.call(block)
+    assert selection == %Selection{start_id: "1", end_id: "3", start_offset: 4, end_offset: 2}
+  end
+
+  test "updates selection when it starts in another cell and ends in from cell" do
+    block = %Block{
+      cells: [
+        %Cell{id: "1", text: "foo", modifiers: ["strong"]},
+        %Cell{id: "2", text: "bar", modifiers: []},
+        %Cell{id: "3", text: "baz", modifiers: []}
+      ],
+      selection: %Selection{start_id: "1", end_id: "3", start_offset: 1, end_offset: 2}
+    }
+
+    assert %{selection: selection} = Reduce.call(block)
+    assert selection == %Selection{start_id: "1", end_id: "2", start_offset: 1, end_offset: 5}
+  end
+end

--- a/test/philtre/editor_test.exs
+++ b/test/philtre/editor_test.exs
@@ -272,14 +272,8 @@ defmodule Philtre.EditorTest do
     Wrapper.trigger_backspace_from_start(view, 2)
     Wrapper.trigger_backspace_from_start(view, 1)
 
-    assert %{blocks: [%Block{type: "h1", cells: [_, _, _, _] = cells}]} = Wrapper.get_editor(view)
-
-    assert [
-             %{text: "This"},
-             %{text: " is "},
-             %{text: "the title of your page"},
-             %{text: "This is your first paragraph."}
-           ] = cells
+    assert %{blocks: [%Block{type: "h1", cells: [cell]}]} = Wrapper.get_editor(view)
+    assert cell.text == "This is the title of your pageThis is your first paragraph."
   end
 
   test "can undo and redo", %{conn: conn} do


### PR DESCRIPTION
Merge and style-toggle operations on blocks result in empty
or generally redundant cells.

This commint introduces cleanup steps to reduce overall number
of cells being managed.

Neighboring cells with the same styles are auto-merged
Blank cells are discarded
Seletion in bot scenarios is kept correct.